### PR TITLE
Empacotador: atualizando dependencias

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.16
 
 require (
 	github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74
-	github.com/dadosjusbr/proto v0.0.0-20211105145754-d5a394d03817
+	github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c
 	github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9
-	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
+	github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74 h1:biTIncJC0X
 github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74/go.mod h1:m9opDykSJIwaf+veICpleWMranaaWEbx5RNQhKZAgXU=
 github.com/dadosjusbr/proto v0.0.0-20211105145754-d5a394d03817 h1:Bnwa3cAohYz0zFM4dZRHSueBBjx979h8OJqTpCkTYpA=
 github.com/dadosjusbr/proto v0.0.0-20211105145754-d5a394d03817/go.mod h1:cUy4r8q1n58ClC4IlsAQ49nr8hIDwA01HiTYAJ1eMVc=
+github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c h1:4b9vaEgN+747yQ5N7Pao/7zcwlD8mvTCH9VUjZM0jFY=
+github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c/go.mod h1:cUy4r8q1n58ClC4IlsAQ49nr8hIDwA01HiTYAJ1eMVc=
 github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9 h1:gwjq5qszD6CxbHQpBzmLH/DXztQeeVszCDVKsrBW/ww=
 github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9/go.mod h1:d6CbzM3Xw9JOsz0AemqOX8DJa315xow0hsw6eTgiDKE=
 github.com/frictionlessdata/tableschema-go v0.1.5-0.20190521014818-f9bf38926664 h1:IvuZMJ6dH1ye2bWmM8Yla6jj1xIPBR/nZJlm6P4ZSD4=
@@ -9,6 +11,8 @@ github.com/frictionlessdata/tableschema-go v0.1.5-0.20190521014818-f9bf38926664/
 github.com/gocarina/gocsv v0.0.0-20200827134620-49f5c3fa2b3e/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8 h1:hp1oqdzmv37vPLYFGjuM/RmUgUMfD9vQfMszc54l55Y=
 github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
+github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48 h1:hLeicZW4XBuaISuJPfjkprg0SP0xxsQmb31aJZ6lnIw=
+github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=


### PR DESCRIPTION
## Atualizando dependências para funcionar com o proto 0.7
Com a adição de novas extensões de arquivos no proto, é necessário atualizar o empacotador para não dar erro nesse estagio.